### PR TITLE
Not clickable repos in mobile view fix

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -236,3 +236,7 @@ body, h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6{
   text-overflow: ellipsis;
   overflow: hidden;
 }
+
+#isotope-container {
+    display: table;
+}


### PR DESCRIPTION
This closes #109 

Explanation issue was the height was 0px due to inner floated elements. I just added `display : table`